### PR TITLE
Add support for rug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "num-bigint 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ramp 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rug 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-gmp 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -30,6 +31,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "gcc"
 version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gmp-mpfr-sys"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -115,6 +121,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rug"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gmp-mpfr-sys 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rust-gmp"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum gmp-mpfr-sys 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c08686f1c3bcd8bdd21e0932e4bb0338badc71313e58a6c1fc61cee61701590a"
 "checksum hamming 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65043da274378d68241eb9a8f8f8aa54e349136f7b8e12f63e3ef44043cc30e1"
 "checksum ieee754 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24477af62edd96fc8de28c9a9b719d9c0e1c9f84838f2a757642215d33664ead"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
@@ -167,6 +182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ramp 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f28e2ee8a80a8438bb9c269eec0ec7f4e15af2179fd30c2d1181e508d406e635"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum rug 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "39b5d276e75328f0d85ac148c78731913689079af166d71688eea57590338a63"
 "checksum rust-gmp 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3ddf28998d5730b96a9fe188557953de503d77ff403ae175ad1417921e5d906"
 "checksum rustc-cfg 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37937dfed502ccc4e644c3cc272222e31adc2b1f5d215f6f8f8e1a422072e516"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ rust-gmp = "0.5"
 [dependencies.num-bigint]
 default-features = false
 version = "0.1"
+
+[dependencies.rug]
+default-features = false
+features = ["integer"]
+version = "0.9"

--- a/benches/mulmod.rs
+++ b/benches/mulmod.rs
@@ -3,11 +3,13 @@
 extern crate num_traits;
 extern crate num_bigint;
 extern crate gmp;
+extern crate rug;
 extern crate test;
 
 use gmp::mpz::Mpz;
 use num_traits::Num;
 use num_bigint::BigInt;
+use rug::Integer as RugInt;
 use test::Bencher;
 
 const P: &'static str = "13407807929942597099574024998205846127479365820592393377723561443721764030073546976801874298166903427690031858186486050853753882811946569946433649006084171";
@@ -28,4 +30,12 @@ fn bigint_mulmod(b: &mut Bencher) {
     let g = BigInt::from_str_radix(G, 10).unwrap();
     let h = BigInt::from_str_radix(H, 10).unwrap();
     b.iter(|| (&g * &h) % &p);
+}
+
+#[bench]
+fn rugint_mulmod(b: &mut Bencher) {
+    let p = RugInt::from_str_radix(P, 10).unwrap();
+    let g = RugInt::from_str_radix(G, 10).unwrap();
+    let h = RugInt::from_str_radix(H, 10).unwrap();
+    b.iter(|| RugInt::from(&g * &h) % &p);
 }


### PR DESCRIPTION
This commit adds support for rug. One side effect is that since rug depends on gmp-mpfr-sys, and gmp-mpfr-sys builds the GMP library from source, the rust-gmp crate will use the library built here so there is no need for GMP to be installed beforehand after this commit.